### PR TITLE
Update Giphy App so that it works on new Apps Engine

### DIFF
--- a/giphy/Giphy.ts
+++ b/giphy/Giphy.ts
@@ -2,9 +2,10 @@ import {
     IConfigurationExtend,
     IEnvironmentRead,
     ILogger,
-} from '@rocket.chat/apps-ts-definition/accessors';
-import { App } from '@rocket.chat/apps-ts-definition/App';
-import { IAppInfo } from '@rocket.chat/apps-ts-definition/metadata';
+} from '@rocket.chat/apps-engine/definition/accessors';
+
+import { App } from '@rocket.chat/apps-engine/definition/App';
+import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 
 import { GiphyCommand } from './commands/GiphyCommand';
 import { GifGetter } from './helpers/GifGetter';

--- a/giphy/app.json
+++ b/giphy/app.json
@@ -3,7 +3,7 @@
     "name": "Giphy",
     "nameSlug": "giphy",
     "version": "0.1.5",
-    "requiredApiVersion": "0.9.13",
+    "requiredApiVersion": "1.3.2",
     "description": "Giphy Rocket.Chat App",
     "author": {
         "name": "Bradley Hilton",

--- a/giphy/commands/GiphyCommand.ts
+++ b/giphy/commands/GiphyCommand.ts
@@ -1,5 +1,5 @@
-import { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-ts-definition/accessors';
-import { ISlashCommand, ISlashCommandPreview, ISlashCommandPreviewItem, SlashCommandContext } from '@rocket.chat/apps-ts-definition/slashcommands';
+import { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';
+import { ISlashCommand, ISlashCommandPreview, ISlashCommandPreviewItem, SlashCommandContext } from '@rocket.chat/apps-engine/definition/slashcommands';
 
 import { GiphyApp } from '../Giphy';
 import { GiphyResult } from '../helpers/GiphyResult';
@@ -65,7 +65,7 @@ export class GiphyCommand implements ISlashCommand {
             this.app.getLogger().error('Failed getting a gif', e);
             builder.setText('An error occured when trying to send the gif :disappointed_relieved:');
 
-            modify.getNotifer().notifyUser(context.getSender(), builder.getMessage());
+            modify.getNotifier().notifyUser(context.getSender(), builder.getMessage());
         }
     }
 }

--- a/giphy/helpers/GifGetter.ts
+++ b/giphy/helpers/GifGetter.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCode, IHttp, ILogger } from '@rocket.chat/apps-ts-definition/accessors';
+import { HttpStatusCode, IHttp, ILogger } from '@rocket.chat/apps-engine/definition/accessors';
 
 import { GiphyResult } from '../helpers/GiphyResult';
 

--- a/giphy/helpers/GiphyResult.ts
+++ b/giphy/helpers/GiphyResult.ts
@@ -1,4 +1,4 @@
-import { ISlashCommandPreviewItem, SlashCommandPreviewItemType } from '@rocket.chat/apps-ts-definition/slashcommands';
+import { ISlashCommandPreviewItem, SlashCommandPreviewItemType } from '@rocket.chat/apps-engine/definition/slashcommands';
 
 export class GiphyResult {
     public id: string;

--- a/giphy/package-lock.json
+++ b/giphy/package-lock.json
@@ -2,17 +2,48 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
-        "@rocket.chat/apps-ts-definition": {
-            "version": "0.9.13",
-            "resolved": "https://registry.npmjs.org/@rocket.chat/apps-ts-definition/-/apps-ts-definition-0.9.13.tgz",
-            "integrity": "sha512-2fqbJG8TPq19o2uZCE3UqRpNobAfAcgu0WkM8PAmhf1de459Z2gbmzbCBAsQJq6eOrGkqDry0GTzEneiCEvwZg==",
-            "dev": true
+        "@rocket.chat/apps-engine": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.4.0.tgz",
+            "integrity": "sha512-zBkNvQlEqfmoMjU9zYGktq2S2MzrBOk7EPY6QjU1CydQdV2ZxgpYlSRryJMb2U+ugSwrkYOnqNw2aQ5brtUsaA==",
+            "requires": {
+                "adm-zip": "^0.4.9",
+                "lodash.clonedeep": "^4.5.0",
+                "semver": "^5.5.0",
+                "stack-trace": "0.0.10",
+                "typescript": "^2.9.2",
+                "uuid": "^3.2.1"
+            }
+        },
+        "adm-zip": {
+            "version": "0.4.13",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+            "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "typescript": {
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
-            "dev": true
+            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
     }
 }

--- a/giphy/package.json
+++ b/giphy/package.json
@@ -1,6 +1,8 @@
 {
     "devDependencies": {
-        "@rocket.chat/apps-ts-definition": "^0.9.13",
         "typescript": "^2.9.1"
+    },
+    "dependencies": {
+        "@rocket.chat/apps-engine": "^1.4.0"
     }
 }


### PR DESCRIPTION
I tried to package and install your Giphy example app against the current RocketChat release and it would not install, so I updated it to use the new apps-engine definitions and bumped the API version requirement number, and this version installs now on my instance.

I thought this change might be useful upstream. Please let me know if it needs additional attention and feel free to simply close the PR if you don't want the contribution.